### PR TITLE
use `realpath call` instead of `realpath program`

### DIFF
--- a/Util/Util.cpp
+++ b/Util/Util.cpp
@@ -9,6 +9,7 @@
 =============================================================================*/
 
 #include "Util.h"
+#include "limits.h"
 
 using namespace std;
 
@@ -887,10 +888,9 @@ Util::getSystemOutput(string cmd)
 string
 Util::getExactPath(const char *str)
 {
-    string cmd = "realpath ";
-    cmd += string(str);
-
-    return getSystemOutput(cmd);
+    char resolved_path[PATH_MAX];
+    realpath(str, resolved_path);
+    return resolved_path;
 }
 
 void


### PR DESCRIPTION
In [System Requirements](https://github.com/Caesar11/gStore/blob/master/docs/DEMAND.md), `realpath` is needed if using `gconsole`. Actually it is needed by `gserver`  and others.

```shell
$ ./bin/gserver -s
the current settings are as below:
key : value
------------------------------------------------------------
buffer_maxium : 100
db_home : .
db_suffix : .db
debug_level : simple
gstore_mode : single
operation_logs : true
thread_maxium : 1000

realpath ./bin/gserver > .tmp/ans.txt
sh: realpath: command not found
pidof  > .tmp/ans.txt
gServer already running!
```

Instead of using `realpath program` in shell, there is a `realpath call` in Linux. [realpath(3) - Linux man page](https://linux.die.net/man/3/realpath). Use it to remove the dependency of realpath program