### PR TITLE
fix the missing '#' in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 #This Dockerfile is just a primitive one. We welcome optimization and simplification.
 
 #Attention: 
-It is best to update the process of modification in the rear of the original code(reduce the order changes).
-Otherwise the speed of construction will be influenced on a large scale.
+#It is best to update the process of modification in the rear of the original code(reduce the order changes).
+#Otherwise the speed of construction will be influenced on a large scale.
 
 #TODO: some space can be saved by using the low version of gcc mirror(e.g-gcc:5).
-But its mobility and dependence has not been tested yet and waiting for confirmation.
+#But its mobility and dependence has not been tested yet and waiting for confirmation.
 
 FROM gcc:8
 
@@ -21,15 +21,15 @@ COPY . /usr/src/gstore
 WORKDIR /usr/src/gstore
 
 #ENV CC="ccache gcc" CXX="ccache g++"? should not be choosed.
-Because it will trigger extremely troublesome bugs and its reason is still waiting for checking.
+#Because it will trigger extremely troublesome bugs and its reason is still waiting for checking.
 
 #The solution to the problem of java, whose default setting is using ansii to encode.
 ENV LANG C.UTF-8
 
 
 #Make compiling will be executed or replaced automatically when the container launch. 
-notice: RUN make still has some problems now. 
+#notice: RUN make still has some problems now. 
 
 #Subsequent test version can be put here.
-And some procedures you need can also be attached here.
+#And some procedures you need can also be attached here.
 CMD ["make"]


### PR DESCRIPTION
Sorry for a  mistake in Dockerfile...
One of our team forgot to add comment symbols(#) when translating..  